### PR TITLE
fix(be): Fix Glue script to accept empty table as input

### DIFF
--- a/source/constructs/config/job/script/glue-job.py
+++ b/source/constructs/config/job/script/glue-job.py
@@ -324,7 +324,7 @@ def detect_df(df, spark, glueContext, udf_dict, broadcast_template, table, regio
             StructField("sample_data", ArrayType(StringType()), True),
         ])
 
-        data_frame = spark.createDataFrame([(None, "", "")], empty_df_schema)
+        data_frame = spark.createDataFrame([(None, "", ["Table size is 0"])], empty_df_schema)
 
     s3_location, s3_bucket, rds_instance_id = get_table_info(table, args)
     # data_frame = spark.createDataFrame(data=items, schema=schema)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Update the detection output for empty table

*How Has This Been Tested:*

*[x] My testing has passed*

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

