### PR TITLE
fix(fe): do not call sync when account list is empty

### DIFF
--- a/source/portal/src/pages/account-management/componments/AccountList.tsx
+++ b/source/portal/src/pages/account-management/componments/AccountList.tsx
@@ -107,7 +107,9 @@ const AccountList: React.FC<any> = (props: any) => {
           });
         });
       const getAccountListresult: any = await getAccountList(requestParam);
-      await refreshAllAccountData(getAccountListresult.items);
+      if (getAccountListresult?.items?.length > 0) {
+        await refreshAllAccountData(getAccountListresult.items);
+      }
       const result: any = await getAccountList(requestParam);
       setSelectedItems([]);
       setPageData(result.items);


### PR DESCRIPTION
1. do not call sync api when account list is empty
