### PR TITLE
fix(be): update retry logic for grant permissions

### DIFF
--- a/source/constructs/api/common/enum.py
+++ b/source/constructs/api/common/enum.py
@@ -89,7 +89,6 @@ class MessageEnum(Enum):
     SOURCE_ORG_ADD_ACCOUNT_FAILED = {1227: "Add account by Organizations failed"}
     SOURCE_RDS_NO_VPC_SECRET_MANAGER_ENDPOINT = {1228: "Could not find secret manager endpoint or NAT gateway for "
                                                        "subnetId in VPC"}
-    SOURCE_GRANT_PERMISSIONS_ERROR = {1229: "The creation of the connection is busy, please try again later"}
 
     # label
     LABEL_EXIST_FAILED = {1611: "Cannot create duplicated label"}

--- a/source/constructs/api/data_source/service.py
+++ b/source/constructs/api/data_source/service.py
@@ -20,6 +20,7 @@ from . import schemas
 
 SLEEP_TIME = 5
 SLEEP_MIN_TIME = 2
+GRANT_PERMISSIONS_RETRIES = 10
 
 # for delegated account(IT), admin account could use this role to list stackset in IT account.
 # CloudFormation Role name is: ListOrganizationRole
@@ -143,7 +144,7 @@ def sync_s3_connection(account: str, region: str, bucket: str):
                                           role_name='GlueDetectionJobRole')
 
         # retry for grant permissions
-        num_retries = 4
+        num_retries = GRANT_PERMISSIONS_RETRIES
         while num_retries > 0:
             try:
                 response = lakeformation.grant_permissions(
@@ -164,8 +165,7 @@ def sync_s3_connection(account: str, region: str, bucket: str):
             else:
                 break
         else:
-            raise BizException(MessageEnum.SOURCE_GRANT_PERMISSIONS_ERROR.get_code(),
-                               MessageEnum.SOURCE_GRANT_PERMISSIONS_ERROR.get_msg())
+            raise Exception('UNCONNECTED')
         try:
             gt_cr_response = glue.get_crawler(Name=crawler_name)
             logger.info(gt_cr_response)
@@ -553,7 +553,7 @@ def sync_rds_connection(account: str, region: str, instance_name: str, rds_user=
                                          region_name=region)
             """ :type : pyboto3.lakeformation """
             # retry for grant permissions
-            num_retries = 4
+            num_retries = GRANT_PERMISSIONS_RETRIES
             while num_retries > 0:
                 try:
                     response = lakeformation.grant_permissions(
@@ -574,8 +574,7 @@ def sync_rds_connection(account: str, region: str, instance_name: str, rds_user=
                 else:
                     break
             else:
-                raise BizException(MessageEnum.SOURCE_GRANT_PERMISSIONS_ERROR.get_code(),
-                                   MessageEnum.SOURCE_GRANT_PERMISSIONS_ERROR.get_msg())
+                raise Exception('UNCONNECTED')
             jdbc_targets = []
             for schema in schema_list:
                 jdbc_targets.append(


### PR DESCRIPTION
Sometimes connect all S3 buckets failed because of grant permission delay 

**What is the updated behavior?

Add retry for the grant method(4 times)

**Checklist

Please check off the following items before submitting your pull request:

- [x] I have tested my changes.
- [x] No sensitive information is included.
- [x] I've reviewed my changes to ensure they won't cause any new issues that could affect the stability or performance of the codebase.