### PR TITLE
fix(be): Add preprocessing to dataframe in Glue script

### DIFF
--- a/source/constructs/config/job/script/glue-job.py
+++ b/source/constructs/config/job/script/glue-job.py
@@ -271,6 +271,14 @@ def sdps_entity_detection(df, threshold, detect_column_udf):
     
     return result_df
 
+def preprocess_df(df):
+    df = df.select([sf.col(c).cast("string") for c in df.columns])
+
+    # Select first 128 characters of each string column
+    df = df.select([sf.substring(c, 1, 128).alias(c) if t == "string" else c for c, t in df.dtypes])
+
+    return df
+
 def detect_df(df, spark, glueContext, udf_dict, broadcast_template, table, region, args):
     """
     detect_table is the main function to perform PII detection in a crawler table.
@@ -292,6 +300,7 @@ def detect_df(df, spark, glueContext, udf_dict, broadcast_template, table, regio
             sample_rate = float(args['Depth'])
 
         df = df.sample(sample_rate)
+        df = preprocess_df(df)
         # print(rows)
         sample_df = df.limit(10)
         # sample_df.show()


### PR DESCRIPTION
**What is the current behavior?

In previous implementation, we did not perform preprocessing in the Glue script. This might cause the stuck inside the job when the text in one cell is too long.

**What is the updated behavior?

Add preprocessing in the Glue script. The script will convert all columns to string type and perform truncation with length 128 before entity detection.

**Checklist

Please check off the following items before submitting your pull request:

- [ * ] I have tested my changes.
- [ * ] No sensitive information is included.
- [ * ] I've reviewed my changes to ensure they won't cause any new issues that could affect the stability or performance of the codebase.

Please check off the following items if this changes include API modefications:

- [ * ] I confirm this changes has been test with [authorization validation steps](https://github.com/awslabs/sensitive-data-protection-on-aws/blob/main/CONTRIBUTING.md#contributing-via-pull-requests), it won't break the authorization token verification mechanism.
- [ * ] I confirm this changes won't cause security issues.