### PR TITLE
fix(others): Support only private subnets.

### DIFF
--- a/source/constructs/bin/main.ts
+++ b/source/constructs/bin/main.ts
@@ -35,6 +35,11 @@ stackSuppressions(
       synthesizer: synthesizer(),
       existingVpc: true,
     }),
+    new AdminStack(app, 'AdminOnlyPrivateSubnets', {
+      synthesizer: synthesizer(),
+      existingVpc: true,
+      onlyPrivateSubnets: true,
+    }),
     new ITStack(app, 'IT', {
       synthesizer: synthesizer(),
     }),

--- a/source/constructs/lib/admin-stack.ts
+++ b/source/constructs/lib/admin-stack.ts
@@ -58,14 +58,18 @@ export interface AdminProps extends StackProps {
    * @default - false.
    */
   existingVpc?: boolean;
+
+  /**
+   * When using an existing VPC, only use a private subnet
+   *
+   * @default - false.
+   */
+  onlyPrivateSubnets?: boolean;
 }
 
-export const enum AuthType {
-  COGNITO = 'AMAZON_COGNITO_USER_POOLS',
-  OIDC = 'OPENID_CONNECT',
-}
 // Admin stack
 export class AdminStack extends Stack {
+  private internetFacing = 'Yes';
 
   constructor(scope: Construct, id: string, props?: AdminProps) {
     super(scope, id, props);
@@ -93,14 +97,21 @@ export class AdminStack extends Stack {
       oidcClientId.logicalId,
     );
 
-    // ALB Paramter
-    const internetFacing = new CfnParameter(this, 'AlbInternetFacing', {
-      type: 'String',
-      default: 'Yes',
-      description: 'If you choose No, the portal website can be accessed ONLY in the VPC. If you want to access the portal website over Internet, you need to choose Yes',
-      allowedValues: ['Yes', 'No'],
-    });
-    Parameter.addToParamLabels('Public Access', internetFacing.logicalId);
+    const paramNetwork = [];
+    if (props?.onlyPrivateSubnets) {
+      this.internetFacing = 'No';
+    } else {
+      // ALB Paramter
+      const internetFacing = new CfnParameter(this, 'AlbInternetFacing', {
+        type: 'String',
+        default: 'Yes',
+        description: 'If you choose No, the portal website can be accessed ONLY in the VPC. If you want to access the portal website over Internet, you need to choose Yes',
+        allowedValues: ['Yes', 'No'],
+      });
+      Parameter.addToParamLabels('Public Access', internetFacing.logicalId);
+      paramNetwork.push(internetFacing.logicalId);
+      this.internetFacing = internetFacing.valueAsString;
+    }
     const port = new CfnParameter(this, 'AlbPort', {
       type: 'Number',
       default: 80,
@@ -109,6 +120,7 @@ export class AdminStack extends Stack {
       description: 'If an ACM certificate ARN has been added, we recommend using port 443 as the default port for HTTPS protocol. Otherwise, port 80 can be set as an alternative option',
     });
     Parameter.addToParamLabels('Port', port.logicalId);
+    paramNetwork.push(port.logicalId);
     const certificate = new CfnParameter(this, 'AlbCertificate', {
       type: 'String',
       default: '',
@@ -116,22 +128,22 @@ export class AdminStack extends Stack {
       description: 'To enable secure communication through encryption and enhancing the security of the solution, you can add a public certificate ARN from ACM to create the portal website URL based on the HTTPS protocol',
     });
     Parameter.addToParamLabels('ACM Certificate ARN (optional)', certificate.logicalId);
+    paramNetwork.push(certificate.logicalId);
     const domainName = new CfnParameter(this, 'CustomDomainName', {
       type: 'String',
       default: '',
       description: 'By adding your own domain name, such as sdps.example.com, you can directly access the portal website by adding a CNAME record to that domain name after deploying the stack.Only fill in the domain name, do not fill in http(s)://',
     });
     Parameter.addToParamLabels('Custom Domain Name (optional)', domainName.logicalId);
+    paramNetwork.push(domainName.logicalId);
     Parameter.addToParamGroups(
       'Network Access',
-      internetFacing.logicalId,
-      port.logicalId,
-      certificate.logicalId,
-      domainName.logicalId,
+      ...paramNetwork,
     );
 
     const vpcStack = new VpcStack(this, 'VPC', {
       existingVpc: props?.existingVpc,
+      onlyPrivateSubnets: props?.onlyPrivateSubnets,
     });
 
     const rdsStack = new RdsStack(this, 'RDS', {
@@ -166,10 +178,11 @@ export class AdminStack extends Stack {
           privateSubnet1: vpcStack.privateSubnet1,
           privateSubnet2: vpcStack.privateSubnet2,
         },
+        onlyPrivateSubnets: props.onlyPrivateSubnets,
         bucket: bucketStack.bucket,
         apiFunction: apiStack.apiFunction,
         port: port.valueAsNumber,
-        internetFacing: internetFacing.valueAsString,
+        internetFacing: this.internetFacing,
         certificateArn: '',
         oidcIssuer: oidcIssuer.valueAsString,
         oidcClientId: oidcClientId.valueAsString,
@@ -185,10 +198,11 @@ export class AdminStack extends Stack {
           privateSubnet1: vpcStack.privateSubnet1,
           privateSubnet2: vpcStack.privateSubnet2,
         },
+        onlyPrivateSubnets: props.onlyPrivateSubnets,
         bucket: bucketStack.bucket,
         apiFunction: apiStack.apiFunction,
         port: port.valueAsNumber,
-        internetFacing: internetFacing.valueAsString,
+        internetFacing: this.internetFacing,
         certificateArn: certificate.valueAsString,
         oidcIssuer: oidcIssuer.valueAsString,
         oidcClientId: oidcClientId.valueAsString,
@@ -201,7 +215,7 @@ export class AdminStack extends Stack {
         bucket: bucketStack.bucket,
         apiFunction: apiStack.apiFunction,
         port: port.valueAsNumber,
-        internetFacing: internetFacing.valueAsString,
+        internetFacing: this.internetFacing,
         certificateArn: '',
         oidcIssuer: oidcIssuer.valueAsString,
         oidcClientId: oidcClientId.valueAsString,
@@ -214,7 +228,7 @@ export class AdminStack extends Stack {
         bucket: bucketStack.bucket,
         apiFunction: apiStack.apiFunction,
         port: port.valueAsNumber,
-        internetFacing: internetFacing.valueAsString,
+        internetFacing: this.internetFacing,
         certificateArn: certificate.valueAsString,
         oidcIssuer: oidcIssuer.valueAsString,
         oidcClientId: oidcClientId.valueAsString,

--- a/source/constructs/lib/admin/rds-stack.ts
+++ b/source/constructs/lib/admin/rds-stack.ts
@@ -35,7 +35,7 @@ import {
   Credentials,
   DatabaseInstance,
   DatabaseInstanceEngine,
-  DatabaseSecret, MysqlEngineVersion,
+  DatabaseSecret, MysqlEngineVersion, StorageType,
 } from 'aws-cdk-lib/aws-rds';
 import {
   SecretRotation,
@@ -97,6 +97,9 @@ export class RdsStack extends Construct {
         InstanceClass.BURSTABLE3,
         InstanceSize.MEDIUM,
       ),
+      storageType: StorageType.GP3,
+      allocatedStorage: 100,
+      maxAllocatedStorage: 1000,
       databaseName: 'sdps', //Do not modify the value
       instanceIdentifier: `${SolutionInfo.SOLUTION_NAME_ABBR}-RDS`,
       vpc: props.vpc,

--- a/source/constructs/lib/admin/vpc-stack.ts
+++ b/source/constructs/lib/admin/vpc-stack.ts
@@ -47,6 +47,12 @@ export interface VpcProps {
    * @default - false.
    */
   existingVpc?: boolean;
+  /**
+   * When using an existing VPC, only use a private subnet
+   *
+   * @default - false.
+   */
+  onlyPrivateSubnets?: boolean;
   readonly internetFacing?: boolean;
 }
 
@@ -65,7 +71,7 @@ export class VpcStack extends Construct {
     super(scope, id);
 
     if (props?.existingVpc) {
-      this.selectExistingVpc(scope);
+      this.selectExistingVpc(scope, props.onlyPrivateSubnets ?? false);
     } else {
       this.createVpc(props);
     }
@@ -126,7 +132,10 @@ export class VpcStack extends Construct {
     });
   }
 
-  private selectExistingVpc(scope: Construct) {
+  private selectExistingVpc(scope: Construct, onlyPrivateSubnets: boolean) {
+    const param = [];
+    let publicSubnetIds = undefined;
+
     const VPC_ID_PARRERN = '^vpc-[a-f0-9]+$';
 
     const vpcId = new CfnParameter(scope, 'VpcId', {
@@ -135,45 +144,51 @@ export class VpcStack extends Construct {
       allowedPattern: `^${VPC_ID_PARRERN}$`,
       constraintDescription: `VPC id must match pattern ${VPC_ID_PARRERN}`,
     });
+    param.push(vpcId.logicalId);
+    this.vpcId = vpcId.valueAsString;
 
-    const publicSubnet1 = new CfnParameter(scope, 'PublicSubnet1', {
-      description: 'Select one public subnet in Availability Zone 1.',
-      type: 'AWS::EC2::Subnet::Id',
-    });
+    if (!onlyPrivateSubnets) {
+      publicSubnetIds = [];
+      const publicSubnet1 = new CfnParameter(scope, 'PublicSubnet1', {
+        description: 'Select one public subnet in Availability Zone 1.',
+        type: 'AWS::EC2::Subnet::Id',
+      });
+      param.push(publicSubnet1.logicalId);
+      publicSubnetIds.push(publicSubnet1.valueAsString);
+      this.publicSubnet1 = publicSubnet1.valueAsString;
 
-    const publicSubnet2 = new CfnParameter(scope, 'PublicSubnet2', {
-      description: 'Select one public subnet in Availability Zone 2.',
-      type: 'AWS::EC2::Subnet::Id',
-    });
+      const publicSubnet2 = new CfnParameter(scope, 'PublicSubnet2', {
+        description: 'Select one public subnet in Availability Zone 2.',
+        type: 'AWS::EC2::Subnet::Id',
+      });
+      param.push(publicSubnet2.logicalId);
+      publicSubnetIds.push(publicSubnet2.valueAsString);
+      this.publicSubnet2 = publicSubnet2.valueAsString;
+    }
 
     const privateSubnet1 = new CfnParameter(scope, 'PrivateSubnet1', {
       description: 'The private subnet must have a route to NatGateway.Select one private subnet in Availability Zone 1.',
       type: 'AWS::EC2::Subnet::Id',
     });
+    param.push(privateSubnet1.logicalId);
 
     const privateSubnet2 = new CfnParameter(scope, 'PrivateSubnet2', {
       description: 'The private subnet must have a route to NatGateway.Select one private subnet in Availability Zone 2.',
       type: 'AWS::EC2::Subnet::Id',
     });
+    param.push(privateSubnet2.logicalId);
 
     Parameter.addToParamGroups(
       'VPC Settings',
-      vpcId.logicalId,
-      publicSubnet1.logicalId,
-      publicSubnet2.logicalId,
-      privateSubnet1.logicalId,
-      privateSubnet2.logicalId,
+      ...param,
     );
 
     this.vpc = Vpc.fromVpcAttributes(scope, 'ExistingVpc', {
       vpcId: vpcId.valueAsString,
       availabilityZones: [0, 1].map(i => Fn.select(i, Fn.getAzs())),
       privateSubnetIds: [privateSubnet1.valueAsString, privateSubnet2.valueAsString],
-      publicSubnetIds: [publicSubnet1.valueAsString, publicSubnet2.valueAsString],
+      publicSubnetIds: publicSubnetIds,
     });
-    this.vpcId = vpcId.valueAsString;
-    this.publicSubnet1 = publicSubnet1.valueAsString;
-    this.publicSubnet2 = publicSubnet2.valueAsString;
     this.privateSubnet1 = privateSubnet1.valueAsString;
     this.privateSubnet2 = privateSubnet2.valueAsString;
 
@@ -187,46 +202,60 @@ export class VpcStack extends Construct {
       ],
     });
 
-    new CfnRule(scope, 'SubnetsNoRepeat', {
-      assertions: [
-        {
-          assert: Fn.conditionNot(Fn.conditionContains([
-            publicSubnet2.valueAsString,
-            privateSubnet1.valueAsString,
-            privateSubnet2.valueAsString,
-          ],
-          publicSubnet1.valueAsString)),
-          assertDescription: 'All subnets must NOT Repeat',
-        },
-        {
-          assert: Fn.conditionNot(Fn.conditionContains([
-            publicSubnet1.valueAsString,
-            privateSubnet1.valueAsString,
-            privateSubnet2.valueAsString,
-          ],
-          publicSubnet2.valueAsString)),
-          assertDescription: 'All subnets must NOT Repeat',
-        },
-        {
-          assert: Fn.conditionNot(Fn.conditionContains([
-            publicSubnet1.valueAsString,
-            publicSubnet2.valueAsString,
-            privateSubnet2.valueAsString,
-          ],
-          privateSubnet1.valueAsString)),
-          assertDescription: 'All subnets must NOT Repeat',
-        },
-        {
-          assert: Fn.conditionNot(Fn.conditionContains([
-            publicSubnet1.valueAsString,
-            publicSubnet2.valueAsString,
-            privateSubnet1.valueAsString,
-          ],
-          privateSubnet2.valueAsString)),
-          assertDescription: 'All subnets must NOT Repeat',
-        },
-      ],
-    });
+    if (onlyPrivateSubnets) {
+      new CfnRule(scope, 'SubnetsNoRepeat', {
+        assertions: [
+          {
+            assert: Fn.conditionNot(Fn.conditionContains([
+              this.privateSubnet2,
+            ],
+            this.privateSubnet1)),
+            assertDescription: 'All subnets must NOT Repeat',
+          },
+        ],
+      });
+    } else {
+      new CfnRule(scope, 'SubnetsNoRepeat', {
+        assertions: [
+          {
+            assert: Fn.conditionNot(Fn.conditionContains([
+              this.publicSubnet2,
+              this.privateSubnet1,
+              this.privateSubnet2,
+            ],
+            this.publicSubnet1)),
+            assertDescription: 'All subnets must NOT Repeat',
+          },
+          {
+            assert: Fn.conditionNot(Fn.conditionContains([
+              this.publicSubnet1,
+              this.privateSubnet1,
+              this.privateSubnet2,
+            ],
+            this.publicSubnet2)),
+            assertDescription: 'All subnets must NOT Repeat',
+          },
+          {
+            assert: Fn.conditionNot(Fn.conditionContains([
+              this.publicSubnet1,
+              this.publicSubnet2,
+              this.privateSubnet2,
+            ],
+            this.privateSubnet1)),
+            assertDescription: 'All subnets must NOT Repeat',
+          },
+          {
+            assert: Fn.conditionNot(Fn.conditionContains([
+              this.publicSubnet1,
+              this.publicSubnet2,
+              this.privateSubnet1,
+            ],
+            this.privateSubnet2)),
+            assertDescription: 'All subnets must NOT Repeat',
+          },
+        ],
+      });
+    }
 
   }
 }


### PR DESCRIPTION
**What is the current behavior?

When using an existing VPC, the public subnets must exist.

**What is the updated behavior?

Support only private subnets.

**Checklist

Please check off the following items before submitting your pull request:

- [x] I have tested my changes.
- [x] No sensitive information is included.
- [x] I've reviewed my changes to ensure they won't cause any new issues that could affect the stability or performance of the codebase.

Please check off the following items if this changes include API modefications:

- [x] I confirm this changes has been test with [authorization validation steps](https://github.com/awslabs/sensitive-data-protection-on-aws/blob/main/CONTRIBUTING.md#contributing-via-pull-requests), it won't break the authorization token verification mechanism.
- [x] I confirm this changes won't cause security issues.